### PR TITLE
Remove decorators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 node_modules/
 round-slider.js
-round-slider.es.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,0 @@
-const plugins = [
-  "@babel/plugin-proposal-class-properties",
-  ["@babel/plugin-proposal-decorators", { "decoratorsBeforeExport": true }],
-];
-
-module.exports = { plugins };

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,20 +48,6 @@
         "trim-right": "^1.0.1"
       }
     },
-    "@babel/helper-create-class-features-plugin": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.5.5.tgz",
-      "integrity": "sha512-ZsxkyYiRA7Bg+ZTRpPvB6AbOFKTFFK4LrvTet8lInm0V468MWCaSYJE+I7v2z2r8KNLtYiV+K5kTCnR7dvyZjg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-member-expression-to-functions": "^7.5.5",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/helper-replace-supers": "^7.5.5",
-        "@babel/helper-split-export-declaration": "^7.4.4"
-      }
-    },
     "@babel/helper-function-name": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
@@ -82,50 +68,11 @@
         "@babel/types": "^7.0.0"
       }
     },
-    "@babel/helper-member-expression-to-functions": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.5.5.tgz",
-      "integrity": "sha512-5qZ3D1uMclSNqYcXqiHoA0meVdv+xUEex9em2fqMnrk/scphGlGgg66zjMrPJESPwrFJ6sbfFQYUSa0Mz7FabA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.5.5"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.0.0.tgz",
-      "integrity": "sha512-aP/hlLq01DWNEiDg4Jn23i+CXxW/owM4WpDLFUbpjxe4NS3BhLVZQ5i7E0ZrxuQ/vwekIeciyamgB1UIYxxM6A==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "@babel/helper-optimise-call-expression": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.0.0.tgz",
-      "integrity": "sha512-u8nd9NQePYNQV8iPWu/pLLYBqZBa4ZaY1YWRFMuxrid94wKI1QNt67NEZ7GAe5Kc/0LLScbim05xZFWkAdrj9g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.0.0"
-      }
-    },
     "@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
       "integrity": "sha512-CYAOUCARwExnEixLdB6sDm2dIJ/YgEAKDM1MOeMeZu9Ld/bDgVo8aiWrXwcY7OBh+1Ea2uUcVRcxKk0GJvW7QA==",
       "dev": true
-    },
-    "@babel/helper-replace-supers": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.5.5.tgz",
-      "integrity": "sha512-XvRFWrNnlsow2u7jXDuH4jDDctkxbS7gXssrP4q2nUD606ukXHRvydj346wmNg+zAgpFx4MWf4+usfC93bElJg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.5.5",
-        "@babel/helper-optimise-call-expression": "^7.0.0",
-        "@babel/traverse": "^7.5.5",
-        "@babel/types": "^7.5.5"
-      }
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.4.4",
@@ -163,36 +110,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
       "integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
       "dev": true
-    },
-    "@babel/plugin-proposal-class-properties": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
-      "integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.5.5",
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
-    },
-    "@babel/plugin-proposal-decorators": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.4.4.tgz",
-      "integrity": "sha512-z7MpQz3XC/iQJWXH9y+MaWcLPNSMY9RQSthrLzak8R8hCj0fuyNk+Dzi9kfNe/JxxlWQ2g7wkABbgWjW36MTcw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.4.4",
-        "@babel/helper-plugin-utils": "^7.0.0",
-        "@babel/plugin-syntax-decorators": "^7.2.0"
-      }
-    },
-    "@babel/plugin-syntax-decorators": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.2.0.tgz",
-      "integrity": "sha512-38QdqVoXdHUQfTpZo3rQwqQdWtCn5tMv4uV6r2RMfTqNBuv4ZBhz79SfaQWKTVmxHjeFv/DnXVC/+agHCklYWA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.0.0"
-      }
     },
     "@babel/plugin-syntax-dynamic-import": {
       "version": "7.2.0",
@@ -685,16 +602,6 @@
         "@types/estree": "0.0.39",
         "@types/node": "^12.7.2",
         "acorn": "^7.0.0"
-      }
-    },
-    "rollup-plugin-babel": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-babel/-/rollup-plugin-babel-4.3.3.tgz",
-      "integrity": "sha512-tKzWOCmIJD/6aKNz0H1GMM+lW1q9KyFubbWzGiOG540zxPPifnEAHTZwjo0g991Y+DyOZcLqBgqOdqazYE5fkw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "rollup-pluginutils": "^2.8.1"
       }
     },
     "rollup-plugin-babel-minify": {

--- a/package.json
+++ b/package.json
@@ -3,30 +3,27 @@
   "version": "0.1.0",
   "description": "",
   "main": "round-slider.js",
-  "module": "round-slider.es.js",
+  "module": "src/main.js",
   "dependencies": {
     "lit-element": "^2.2.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.5.5",
-    "@babel/plugin-proposal-class-properties": "^7.5.5",
-    "@babel/plugin-proposal-decorators": "^7.4.4",
     "rollup": "^1.20.3",
-    "rollup-plugin-babel": "^4.3.3",
     "rollup-plugin-babel-minify": "^9.0.0",
     "rollup-plugin-node-resolve": "^5.2.0"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "rollup -c",
-    "watch": "rollup -w -c"
+    "watch": "rollup -w -c",
+    "prepublishOnly": "rollup -c"
   },
   "keywords": [],
   "author": "thomasloven",
   "license": "MIT",
   "files": [
     "round-slider.js",
-    "round-slider.es.js"
+    "src/main.js"
   ],
   "repository": {
     "url": "https://github.com/thomasloven/round-slider.git",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,38 +1,12 @@
-import babel from "rollup-plugin-babel";
 import resolve from "rollup-plugin-node-resolve";
 import minify from "rollup-plugin-babel-minify";
 
-export default [
-  {
-    input: "./src/main.js",
-    output: {
-      file: "./round-slider.js",
-      format: "es",
-      compact: true
-    },
-    plugins: [
-      babel({
-        exclude: "node_modules/**"
-      }),
-      resolve(),
-      minify({comments: false}),
-    ]
+export default {
+  input: "./src/main.js",
+  output: {
+    file: "./round-slider.js",
+    format: "es",
+    compact: true
   },
-  {
-    input: "./src/main.js",
-    output: {
-      file: "./round-slider.es.js",
-      format: "es",
-      compact: true
-    },
-    plugins: [
-      babel({
-        exclude: "node_modules/**",
-        externalHelpers: true,
-      })
-    ],
-    "external": [
-      "lit-element"
-    ]
-  }
-];
+  plugins: [resolve(), minify({ comments: false })]
+};

--- a/src/main.js
+++ b/src/main.js
@@ -3,27 +3,39 @@ import {
   html,
   css,
   svg,
-  property,
 } from "lit-element";
 
 class RoundSlider extends LitElement {
 
-  @property({type: Number}) value;
-  @property({type: Number}) high;
-  @property({type: Number}) low;
+  static get properties() {
+    return {
+      value: {type: Number},
+      high: {type: Number},
+      low: {type: Number},
+      min: {type: Number},
+      max: {type: Number},
+      step: {type: Number},
+      radius: {type: Number},
+      startAngle: {type: Number},
+      arcLength: {type: Number},
+      handleSize: {type: Number},
+      disabled: {type: Boolean},
+      dragging: {type: Boolean, reflect: true},
+    }
+  }
 
-  @property({type: Number}) min = 0;
-  @property({type: Number}) max = 100;
-  @property({type: Number}) step = 1;
-
-  @property({type: Number}) radius = 80;
-  @property({type: Number}) startAngle = 135;
-  @property({type: Number}) arcLength = 270;
-
-  @property({type: Number}) handleSize = 6;
-  @property({type: Boolean}) disabled = false;
-
-  @property({type: Boolean, reflect: true}) dragging = false;
+  constructor() {
+    super();
+    this.min = 0;
+    this.max = 100;
+    this.step = 1;
+    this.radius = 80;
+    this.startAngle = 135;
+    this.arcLength = 270;
+    this.handleSize = 6;
+    this.disabled = false;
+    this.dragging = false;
+  }
 
   get _r0() {
     return this.radius;


### PR DESCRIPTION
By removing the decorators, we can point the module field directly at `src/main.js` and can drop babel, reducing the size of round-slider.js. 

With this PR, round-slider.js is 29K. Previously it was 34K. That's a 17% decrease 👍 