### PR TITLE
self-executing function, suitable for inclusion as a <script> tag

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,10 +3,17 @@ import { terser } from "rollup-plugin-terser";
 
 export default {
   input: "./src/main.js",
-  output: {
-    file: "./round-slider.js",
-    format: "cjs",
-    compact: true
-  },
+  output: [
+    {
+      file: "./round-slider.js",
+      format: "cjs",
+      compact: true
+    },
+    {
+      file: "./round-slider.iife.js",
+      format: "iife",
+      compact: true
+    }
+  ],
   plugins: [resolve(), terser()]
 };


### PR DESCRIPTION
cjs format cause conflict with underscore lib, because of redeclaration of `_` var.