### PR TITLE
Revert `browser` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "main": "round-slider.cjs",
   "module": "round-slider.js",
-  "browser": "round-slider.iife.js",
   "typings": "round-slider.d.ts",
   "dependencies": {
     "lit": "^2.0.0-rc.2",

--- a/round-slider.js
+++ b/round-slider.js
@@ -1,6 +1,6 @@
 import { __decorate } from "tslib";
 import { LitElement, html, css, svg, } from "lit";
-import { property, state } from "lit/decorators";
+import { property, state } from "lit/decorators.js";
 export class RoundSlider extends LitElement {
     constructor() {
         super();

--- a/src/round-slider.ts
+++ b/src/round-slider.ts
@@ -8,7 +8,7 @@ import {
   PropertyValues,
   CSSResultGroup,
 } from "lit";
-import { property, state } from "lit/decorators";
+import { property, state } from "lit/decorators.js";
 
 export class RoundSlider extends LitElement {
   @property({ type: Number }) public value: number;


### PR DESCRIPTION
Webpack actually takes `browser` before `module` :-/